### PR TITLE
Fix uneven trailing whitespace in strings

### DIFF
--- a/src/accents.jl
+++ b/src/accents.jl
@@ -20,9 +20,9 @@
 
     """
     Add an acute accent to a single vowel or diphthong.
-    
+
     $(SIGNATURES)
- 
+
     """
     function addacute(vowel::AbstractString, ortho::AtticOrthography)
         bare = PolytonicGreek.stripquant(vowel)


### PR DESCRIPTION
Found as part of JuliaLang/julia#46372 - the reference parser treats triple quoted lines of uneven whitespace in a weird inconsistent way so this is changed in the new parser. This change removes the uneven whitespace.